### PR TITLE
chore: 更新版本至0.1.2，停用OpenMP并添加Wheel包支持Python 3.10-3.13

### DIFF
--- a/lib/quick_algo/CHANGELOG.md
+++ b/lib/quick_algo/CHANGELOG.md
@@ -1,2 +1,6 @@
 # v0.1.1
  - 仅打包 .cpp & .hpp 源码文件，不再打包 .pyx & .pxd ，用户安装包体时不再需要安装Cython
+
+# v0.1.2
+ - 停用OpenMP，避免Linux分发中PageRank的运行错误（且考虑到OpenMP带来的提升并不明显，故暂时不启用）
+ - 添加Wheel包，支持Python 3.10-3.13（Windows、Linux）

--- a/lib/quick_algo/setup.py
+++ b/lib/quick_algo/setup.py
@@ -51,7 +51,7 @@ URL = "https://github.com/MaiM-with-u/MaiMBot-LPMM"
 EMAIL = "octautumn2002@gmail.com"
 AUTHOR = "Oct Autumn"
 REQUIRES_PYTHON = ">=3.10"
-VERSION = "0.1.1"
+VERSION = "0.1.2"
 
 # What packages are required for this module to be executed?
 REQUIRED = [


### PR DESCRIPTION
OpenMP多线程带来的性能提升并不明显，且在Linux上会遇到运行PageRank时报错undefined symbol: omp_get_thread_num，在证实多线程确实有较大性能提升且能解决Linux上的报错之前，不会启用OpenMP。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

将项目版本更新至 0.1.2，并禁用 OpenMP 支持，同时增加对 Python 3.10-3.13 的 Wheel 包兼容性

增强功能：
- 禁用 OpenMP 以解决 Linux 发行版上潜在的 PageRank 运行时错误

杂项：
- 将项目版本从 0.1.1 提升至 0.1.2

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update project version to 0.1.2 and disable OpenMP support while adding Wheel package compatibility for Python 3.10-3.13

Enhancements:
- Disable OpenMP to resolve potential PageRank runtime errors on Linux distributions

Chores:
- Bump project version from 0.1.1 to 0.1.2

</details>