### PR TITLE
new action test

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -4,21 +4,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-sdist:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.10"]
-
+  build-wheel-linux:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
           cache: 'pip'
 
       - name: Install build tools (Ubuntu)
@@ -28,17 +23,17 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install cython build setuptools py-cpuinfo wheel
+          pip install cython build setuptools py-cpuinfo wheel cibuildwheel
 
-      - name: Build source distribution
+      - name: Build wheels (manylinux)
         working-directory: lib/quick_algo
-        run: python ./build_lib.py --cleanup --cythonize --build_sdist
+        run: python -m cibuildwheel --output-dir dist
 
-      - name: Upload source distribution
+      - name: Upload wheel distribution
         uses: actions/upload-artifact@v4
         with:
-          name: sdist
-          path: lib/quick_algo/dist/*.tar.gz
+          name: wheel_manylinux
+          path: lib/quick_algo/dist/*.whl
 
   build-wheel:
     runs-on: ${{ matrix.os }}

--- a/lib/quick_algo/pyproject.toml
+++ b/lib/quick_algo/pyproject.toml
@@ -33,6 +33,7 @@ build = [
     "setuptools",
     "py-cpuinfo",
     "wheel",
+    "cibuildwheel",
 ]
 test = [
     "pytest",
@@ -45,5 +46,20 @@ test = [
 Homepage = "https://github.com/MaiM-with-u/MaiMBot-LPMM"
 Issues = "https://github.com/MaiM-with-u/MaiMBot-LPMM/issues"
 
+[tool.cibuildwheel]
+manylinux-x86_64-image = "manylinux2014"
+manylinux-aarch64-image = "manylinux2014"
+
 [tool.setuptools]
 package-dir = {"" = "src"}
+
+[tool.cibuildwheel.linux]
+repair-wheel-command = "auditwheel repair -w {dest_dir} {wheel}"
+archs = ["x86_64", "aarch64"]
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+repair-wheel-command = [
+  "delocate-listdeps {wheel}",
+  "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}",
+]


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

使用 cibuildwheel 替换源码发行版，并在 GitHub Actions 上构建多架构 wheel 包，并相应地配置构建工具。

增强功能：
- 添加 cibuildwheel 依赖，并在 pyproject.toml 中配置 Linux (manylinux) 和 macOS wheel 包的构建设置

CI：
- 将手动 sdist 任务替换为基于 cibuildwheel 的 wheel 包构建工作流程（在 Linux 上）

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use cibuildwheel to replace source distribution with multi-arch wheel builds on GitHub Actions and configure build tooling accordingly.

Enhancements:
- Add cibuildwheel dependency and configure Linux (manylinux) and macOS wheel build settings in pyproject.toml

CI:
- Replace manual sdist job with a cibuildwheel-based wheel build workflow on Linux

</details>