### PR TITLE
更新构建配置，支持多平台构建和发布，修复macOS构建崩溃问题，优化安装流程

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -1,80 +1,113 @@
-# 对QuickAlgo构建源码分发包和wheel分发包的CI配置
+# 对 QuickAlgo 构建源码分发包和 wheel 分发包的 CI 配置
 name: QuickAlgo Distribution CI
+
 on:
   workflow_dispatch:
+  push:
+    tags:
+      - "quick-algo-v*"
 
 jobs:
-  build-wheel-linux:
-    strategy:
-        matrix:
-          include:
-            - os: ubuntu-latest
-              arch: x86_64
-            - os: ubuntu-24.04-arm
-              arch: arm64
+  build-wheels:
+    name: Build wheels (${{ matrix.os }}-${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: x86_64
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+          - os: windows-latest
+            arch: AMD64
+          - os: macos-13
+            arch: x86_64
+          - os: macos-14
+            arch: arm64
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
-          cache: 'pip'
+          python-version: "3.12"
+          cache: pip
 
-      - name: Install build tools (Ubuntu)
+      - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential
+          python -m pip install --upgrade pip
+          pip install build cibuildwheel cython
 
-      - name: Install dependencies
-        run: |
-          pip install cython build setuptools py-cpuinfo wheel cibuildwheel
-      
       - name: Cythonize files
         working-directory: lib/quick_algo
         run: python ./build_lib.py --cleanup --cythonize
 
-      - name: Build wheels (manylinux)
-        working-directory: lib/quick_algo
+      - name: Build wheels
         env:
-          CIBW_ARCHS: native
-        run: python -m cibuildwheel --output-dir dist
+          CIBW_ARCHS: ${{ matrix.arch }}
+        run: python -m cibuildwheel --output-dir lib/quick_algo/dist lib/quick_algo
 
       - name: Upload wheel distribution
         uses: actions/upload-artifact@v4
         with:
-          name: wheel_manylinux_${{ matrix.arch }}
+          name: wheels-${{ matrix.os }}-${{ matrix.arch }}
           path: lib/quick_algo/dist/*.whl
 
-  build-wheel:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          python-version: "3.12"
+          cache: pip
 
-      - name: Install dependencies
+      - name: Install build dependencies
         run: |
-          pip install cython build setuptools py-cpuinfo wheel
+          python -m pip install --upgrade pip
+          pip install build cython
 
-      - name: Build wheel distribution
+      - name: Cythonize files
         working-directory: lib/quick_algo
-        run: python ./build_lib.py --cleanup --cythonize --build_wheel
+        run: python ./build_lib.py --cleanup --cythonize
 
-      - name: Upload wheel distribution
+      - name: Build source distribution
+        working-directory: lib/quick_algo
+        run: python ./build_lib.py --build_sdist
+
+      - name: Upload source distribution
         uses: actions/upload-artifact@v4
         with:
-          name: wheel_${{ matrix.python-version }}_${{ matrix.os }}
-          path: lib/quick_algo/dist/*.whl
+          name: sdist
+          path: lib/quick_algo/dist/*.tar.gz
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/quick-algo-v')
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+
+      - name: Download source artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -21,9 +21,9 @@ jobs:
             arch: aarch64
           - os: windows-latest
             arch: AMD64
-          - os: macos-14
+          - os: macos-15
             arch: arm64
-          - os: macos-13
+          - os: macos-15-intel
             arch: x86_64
 
     steps:

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build cibuildwheel cython
+          pip install build cibuildwheel cython setuptools
 
       - name: Cythonize files
         working-directory: lib/quick_algo
@@ -70,7 +70,7 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build cython
+          pip install build cython setuptools
 
       - name: Cythonize files
         working-directory: lib/quick_algo

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -23,6 +23,8 @@ jobs:
             arch: AMD64
           - os: macos-14
             arch: arm64
+          - os: macos-13
+            arch: x86_64
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -21,7 +21,7 @@ jobs:
             arch: aarch64
           - os: windows-latest
             arch: AMD64
-          - os: macos-latest
+          - os: macos-14
             arch: arm64
 
     steps:

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -21,9 +21,7 @@ jobs:
             arch: aarch64
           - os: windows-latest
             arch: AMD64
-          - os: macos-13
-            arch: x86_64
-          - os: macos-14
+          - os: macos-latest
             arch: arm64
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-14, macos-13]
         python-version: ["3.12"]
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,7 @@
 # 若lib/quick_algo目录下有文件被修改，则运行pytest
 name: QuickAlgo CI
 on:
+  workflow_dispatch:
   push:
     paths:
       - 'lib/quick_algo/**'
@@ -13,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-14]
         python-version: ["3.10"]
 
     steps:
@@ -26,17 +27,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
 
-      - name: Install build tools (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install build tools (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential
-
       - name: Ensure MSVC Build Tools (Windows)
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         run: |
           echo "MSVC tools will be automatically available on windows-latest"
-
       - name: Install dependencies
         run: |
           pip install cython build setuptools py-cpuinfo wheel pytest numpy scipy networkx

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-14, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-15, macos-15-intel]
         python-version: ["3.12"]
 
     steps:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-14]
-        python-version: ["3.10"]
+        python-version: ["3.12"]
 
     steps:
       - name: Checkout code

--- a/lib/quick_algo/CHANGELOG.md
+++ b/lib/quick_algo/CHANGELOG.md
@@ -9,3 +9,8 @@
  - 取消OpenMP需求
  - SIMD优化
  - 构建脚本优化
+
+# v0.1.4
+ - 修复macOS安装时的构建崩溃问题（去除对 `cpuinfo['flags']` 的硬依赖）
+ - 安装构建流程支持在缺失预生成 `.cpp` 时自动回退到 `.pyx`（无需手动预编译）
+ - 新增macOS wheel构建与发布流程，覆盖Intel（x86_64）和Apple Silicon（arm64）

--- a/lib/quick_algo/MANIFEST.in
+++ b/lib/quick_algo/MANIFEST.in
@@ -1,3 +1,5 @@
 prune tests
-recursive-include src/quick_algo *.cpp *.hpp *.pxd *.pyx *.pyi
+graft src/quick_algo/cpp
+include src/quick_algo/di_graph.pyi
+include src/quick_algo/pagerank.pyi
 include CHANGELOG.md

--- a/lib/quick_algo/MANIFEST.in
+++ b/lib/quick_algo/MANIFEST.in
@@ -1,5 +1,3 @@
 prune tests
-graft src/quick_algo/cpp
-include src/quick_algo/di_graph.pyi
-include src/quick_algo/pagerank.pyi
+recursive-include src/quick_algo *.cpp *.hpp *.pxd *.pyx *.pyi
 include CHANGELOG.md

--- a/lib/quick_algo/README.md
+++ b/lib/quick_algo/README.md
@@ -38,23 +38,28 @@
 - `--cleanup`：清理构建目录和临时文件
 - `--cythonize`：编译Cython代码（要求依赖`cython`）
 - `--force_cythonize`: 强制重新编译Cython代码（要求依赖`cython`）
-- `--build_dist`：构建Python包（要求依赖`setuptools`）
-- `--build_wheel`：构建Python wheel包（要求依赖`setuptools`, 要求C/Cpp编译环境）
+- `--build_sdist`：构建Python源码分发包（要求依赖`setuptools`）
+- `--build_wheel`：构建Python wheel包（要求依赖`setuptools`和C/Cpp编译环境；若无预生成`.cpp`，需先执行`--cythonize`）
 - `--install`：安装Python包（要求依赖`setuptools`, 要求C/Cpp编译环境）
 
 ## 安装
-您可以直接使用`pip install quick_algo`进行安装：
+您可以直接使用`pip install quick-algo`进行安装：
 ```bash
-pip install quick_algo
+pip install quick-algo
 ```
-> 注：PyPI上提供的二进制包默认不开启SIMD优化，您可以通过编译源码分发包来启用该特性
+> 注：PyPI上的预编译wheel默认不开启SIMD优化（兼容优先）。若您希望启用SIMD，可使用源码编译安装。
+
+当前PyPI wheel覆盖：
+- macOS Intel（x86_64）
+- macOS Apple Silicon（arm64）
+- Linux（x86_64 / aarch64）
+- Windows（x86_64）
 
 您也可以在clone本仓库之后通过前述构建脚本于本地进行编译安装。
 
 在编译安装之前，请确保您装有以下依赖：
 - `setuptools`: Python包管理工具
 - `Cython`: Cython编译器
-- `py-cpuinfo`: CPU信息获取库
 - `MSVC/GCC/Clang`: C/Cpp编译环境
 
 要使用脚本编译安装，请在项目目录下执行以下命令：

--- a/lib/quick_algo/pyproject.toml
+++ b/lib/quick_algo/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel", "Cython>=3.0"]
+requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/lib/quick_algo/pyproject.toml
+++ b/lib/quick_algo/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "py-cpuinfo"]
+requires = ["setuptools>=68", "wheel", "Cython>=3.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,7 @@ name = "quick-algo"
 authors = [
     {name="Oct-autumn", email="octautumn2002@gmail.com"},
 ]
-version = "0.1.3"
+version = "0.1.4"
 description = "A fast and efficient algorithm library for LPMM"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -23,17 +23,17 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
 ]
 
 [project.optional-dependencies]
 build = [
-    "cython",
     "build",
-    "setuptools",
-    "py-cpuinfo",
-    "wheel",
     "cibuildwheel",
+    "cython",
+    "setuptools",
+    "wheel",
 ]
 test = [
     "pytest",
@@ -47,6 +47,7 @@ Homepage = "https://github.com/MaiM-with-u/MaiMBot-LPMM"
 Issues = "https://github.com/MaiM-with-u/MaiMBot-LPMM/issues"
 
 [tool.cibuildwheel]
+build-verbosity = 1
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
 
@@ -63,3 +64,6 @@ repair-wheel-command = [
   "delocate-listdeps {wheel}",
   "delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}",
 ]
+
+[tool.cibuildwheel.windows]
+archs = ["AMD64"]

--- a/lib/quick_algo/pyproject.toml
+++ b/lib/quick_algo/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=68", "wheel", "Cython>=3"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -32,6 +32,7 @@ build = [
     "build",
     "cibuildwheel",
     "cython",
+    "py-cpuinfo",
     "setuptools",
     "wheel",
 ]

--- a/lib/quick_algo/setup.py
+++ b/lib/quick_algo/setup.py
@@ -60,7 +60,7 @@ def get_compile_and_link_args():
 
 
 # 解析扩展模块主源文件：优先使用预生成的cpp，缺失时回退到pyx
-# 这样PyPI包无需依赖Cython，而本地源码开发仍可直接构建
+# 当包中包含预生成cpp时无需Cython，仅在回退pyx时才需要Cython
 def resolve_source_file(cpp_source, pyx_source):
     if Path(cpp_source).exists():
         return cpp_source, False

--- a/lib/quick_algo/setup.py
+++ b/lib/quick_algo/setup.py
@@ -1,142 +1,136 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os
-import sys
-import cpuinfo
+from pathlib import Path
 
-from setuptools import find_packages, setup, Extension
+from setuptools import Extension, find_packages, setup
+
+try:
+    from Cython.Build import cythonize
+except ImportError:
+    cythonize = None
+
+import os
+import platform
+import sys
+
 
 platform_info = {
     "os": "Unknown",  # 操作系统
-    "avx2": False,      # 是否支持AVX2指令集
-    "neon": False,      # 是否支持ARM NEON指令集
+    "machine": platform.machine().lower(),  # CPU架构
 }
 
 build_args = {
     "with-simd": os.getenv("QUICK_ALGO_SIMD") == "1"
 }
 
-# 获取平台信息
-def get_platform_info():
-    # 获取操作系统信息
-    if sys.platform.startswith("linux"):
-        platform_info["os"] = "Linux"
-    elif sys.platform.startswith("win"):
-        platform_info["os"] = "Windows"
-    elif sys.platform.startswith("darwin"):
-        platform_info["os"] = "macOS"
 
-    # 获取CPU信息
-    cpu_info = cpuinfo.get_cpu_info()
-    
-    # 检查是否为ARM架构
-    is_arm_platform = False
-    if "arch_string_raw" in cpu_info:
-        arch_raw = cpu_info["arch_string_raw"].lower()
-        is_arm_platform = any(arm_arch in arch_raw for arm_arch in ["aarch64", "arm64", "armv8", "arm"])
-    
-    # 备用检测方法
-    if not is_arm_platform and "arch" in cpu_info:
-        arch = cpu_info["arch"].lower()
-        is_arm_platform = any(arm_arch in arch for arm_arch in ["aarch64", "arm64", "armv8", "arm"])
-    
-    # 将ARM信息保存到platform_info中
-    platform_info["is_arm"] = is_arm_platform
-    
-    print(f"cpu info:{cpu_info}")
-    if "flags" in cpu_info:
-        print(f"CPU Flags: {cpu_info['flags']}")
-    print(f"Detected Platform: {'ARM' if is_arm_platform else 'x86'}")
-    
-    if build_args["with-simd"]:
-        if is_arm_platform:
-            # ARM平台上启用NEON，明确设置AVX2为False
-            platform_info["avx2"] = False
-            
-            # AArch64 处理器均支持NEON
-            if any(arm_arch in cpu_info.get("arch_string_raw", "").lower() 
-                  for arm_arch in ["aarch64", "arm64", "armv8"]):
-                platform_info["neon"] = True
-                print("Enabled ARM NEON support (AArch64)")
-            # 对于ARMv7，需要检查flags中是否有neon标志
-            elif "neon" in cpu_info.get("flags", []):
-                platform_info["neon"] = True
-                print("Enabled ARM NEON support (ARMv7)")
-        else:
-            # 非ARM平台上检查AVX2支持
-            platform_info["neon"] = False
-            if "avx2" in cpu_info.get("flags", []):
-                platform_info["avx2"] = True
+if sys.platform.startswith("linux"):
+    platform_info["os"] = "Linux"
+elif sys.platform.startswith("win"):
+    platform_info["os"] = "Windows"
+elif sys.platform.startswith("darwin"):
+    platform_info["os"] = "macOS"
+
+
+# 检查是否为ARM架构
+def is_arm_platform():
+    return any(
+        arm_arch in platform_info["machine"] for arm_arch in ["aarch64", "arm64", "armv8", "arm"]
+    )
+
 
 # 生成构建参数
 def get_compile_and_link_args():
-    get_platform_info()
-
     compile_args = []
-    
-    print(f"Generating Compilation Parameters - Platform Detection: {'ARM' if platform_info['is_arm'] else 'x86'}")
-    print(f"SIMD support: AVX2={platform_info['avx2']}, NEON={platform_info['neon']}")
-
-    if platform_info["is_arm"]:
-        # 在ARM平台上只使用NEON指令集，不添加AVX2相关参数
-        if platform_info["neon"]:
-            # 对于AArch64，NEON是默认的，不需要额外的编译选项
-            # 但是我们添加宏定义，以便在代码中检测NEON支持
-            compile_args.append("-D__ARM_NEON__")
-            print("Enabled NEON support")
-    else:
-        # 非ARM平台才考虑使用AVX2
-        if platform_info["os"] == "Linux" or platform_info["os"] == "macOS":
-            if platform_info["avx2"]:
-                compile_args.append("-mavx2")
-                compile_args.append("-D__AVX2__")
-                print("Enabled AVX2 support")
-        elif platform_info["os"] == "Windows":
-            if platform_info["avx2"]:
-                compile_args.append("/arch:AVX2")
-                compile_args.append("-D__AVX2__")
-                print("Enabled AVX2 support")
-    
     link_args = []
 
+    if not build_args["with-simd"]:
+        return compile_args, link_args
+
+    if is_arm_platform():
+        compile_args.append("-D__ARM_NEON__")
+        return compile_args, link_args
+
+    if platform_info["os"] in ["Linux", "macOS"]:
+        compile_args.extend(["-mavx2", "-D__AVX2__"])
+    elif platform_info["os"] == "Windows":
+        compile_args.extend(["/arch:AVX2", "/D__AVX2__"])
+
     return compile_args, link_args
+
+
+# 解析扩展模块主源文件：优先使用预生成的cpp，缺失时回退到pyx
+# 这样PyPI包无需依赖Cython，而本地源码开发仍可直接构建
+def resolve_source_file(cpp_source, pyx_source):
+    if Path(cpp_source).exists():
+        return cpp_source, False
+    if Path(pyx_source).exists():
+        return pyx_source, True
+    raise FileNotFoundError(
+        f"Cannot find extension source file, expected one of: {cpp_source}, {pyx_source}"
+    )
+
 
 # 获取扩展模块
 def get_ext_modules():
     compile_args, link_args = get_compile_and_link_args()
-    ext_modules = [
-        Extension(
+    extension_targets = [
+        (
             "quick_algo.di_graph",
-            sources=[
-                "src/quick_algo/di_graph.cpp",
-                "src/quick_algo/cpp/di_graph_impl.cpp",
-            ],
-            include_dirs=[
-                "src/quick_algo"
-            ],
-            extra_compile_args=compile_args,
-            extra_link_args=link_args,
-            language="c++",
+            "src/quick_algo/di_graph.cpp",
+            "src/quick_algo/di_graph.pyx",
+            "src/quick_algo/cpp/di_graph_impl.cpp",
         ),
-        Extension(
+        (
             "quick_algo.pagerank",
-            sources=[
-                "src/quick_algo/pagerank.cpp",
-                "src/quick_algo/cpp/pagerank_impl.cpp",
-            ],
-            include_dirs=[
-                "src/quick_algo",
-            ],
-            extra_compile_args=compile_args,
-            extra_link_args=link_args,
-            language="c++",
+            "src/quick_algo/pagerank.cpp",
+            "src/quick_algo/pagerank.pyx",
+            "src/quick_algo/cpp/pagerank_impl.cpp",
         ),
     ]
 
+    ext_modules = []
+    require_cython = False
+
+    for module_name, cpp_source, pyx_source, cpp_impl in extension_targets:
+        source_entry, use_cython = resolve_source_file(cpp_source, pyx_source)
+        require_cython = require_cython or use_cython
+        ext_modules.append(
+            Extension(
+                module_name,
+                sources=[
+                    source_entry,
+                    cpp_impl,
+                ],
+                include_dirs=[
+                    "src/quick_algo"
+                ],
+                extra_compile_args=compile_args,
+                extra_link_args=link_args,
+                language="c++",
+            )
+        )
+
+    if require_cython:
+        if cythonize is None:
+            raise RuntimeError(
+                "Generated C++ sources are missing. Install Cython, or run "
+                "'python build_lib.py --cythonize' before building quick-algo."
+            )
+
+        return cythonize(
+            ext_modules,
+            compiler_directives={"language_level": 3},
+        )
+
     return ext_modules
+
 
 setup(
     ext_modules=get_ext_modules(),
     packages=find_packages(where="src", exclude=["tests", "*.tests", "*.tests.*", "tests.*", "*/cpp*"]),
-    include_package_data=True,
+    package_data={
+        "quick_algo": ["*.pyi"],
+    },
+    include_package_data=False,
 )

--- a/lib/quick_algo/setup.py
+++ b/lib/quick_algo/setup.py
@@ -20,7 +20,8 @@ platform_info = {
 }
 
 build_args = {
-    "with-simd": os.getenv("QUICK_ALGO_SIMD") == "1"
+    "with-simd": os.getenv("QUICK_ALGO_SIMD") == "1",
+    "force-avx2": os.getenv("QUICK_ALGO_AVX2") == "1",
 }
 
 
@@ -39,6 +40,20 @@ def is_arm_platform():
     )
 
 
+def supports_avx2():
+    """Best-effort AVX2 feature detection without hard dependency on py-cpuinfo."""
+    if build_args["force-avx2"]:
+        return True
+
+    try:
+        import cpuinfo  # type: ignore
+
+        flags = cpuinfo.get_cpu_info().get("flags", [])
+        return "avx2" in [flag.lower() for flag in flags]
+    except Exception:
+        return False
+
+
 # 生成构建参数
 def get_compile_and_link_args():
     compile_args = []
@@ -51,16 +66,24 @@ def get_compile_and_link_args():
         compile_args.append("-D__ARM_NEON__")
         return compile_args, link_args
 
-    if platform_info["os"] in ["Linux", "macOS"]:
-        compile_args.extend(["-mavx2", "-D__AVX2__"])
-    elif platform_info["os"] == "Windows":
-        compile_args.extend(["/arch:AVX2", "/D__AVX2__"])
+    avx2_enabled = supports_avx2()
+    if build_args["with-simd"] and not avx2_enabled:
+        print(
+            "QUICK_ALGO_SIMD=1 is set, but AVX2 is not detected on this host. "
+            "Building without AVX2 flags."
+        )
+
+    if avx2_enabled:
+        if platform_info["os"] in ["Linux", "macOS"]:
+            compile_args.extend(["-mavx2", "-D__AVX2__"])
+        elif platform_info["os"] == "Windows":
+            compile_args.extend(["/arch:AVX2", "/D__AVX2__"])
 
     return compile_args, link_args
 
 
 # 解析扩展模块主源文件：优先使用预生成的cpp，缺失时回退到pyx
-# 当包中包含预生成cpp时无需Cython，仅在回退pyx时才需要Cython
+# 为了兼容PEP 517隔离构建，build-system中已声明Cython；但仍优先使用预生成cpp
 def resolve_source_file(cpp_source, pyx_source):
     if Path(cpp_source).exists():
         return cpp_source, False

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     print("未找到quick_algo库，无法使用quick_algo算法")
     print("请先安装quick_algo库：pip install quick-algo")
+    raise SystemExit(1)
 
 
 import sys

--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
 try:
-    import lib.quick_algo
+    import quick_algo
 except ImportError:
     print("未找到quick_algo库，无法使用quick_algo算法")
-    print("请安装quick_algo库 - 在lib.quick_algo中，执行命令：python setup.py build_ext --inplace")
+    print("请先安装quick_algo库：pip install quick-algo")
 
 
 import sys

--- a/main.py
+++ b/main.py
@@ -1,9 +1,8 @@
 try:
-    import quick_algo
+    import lib.quick_algo
 except ImportError:
     print("未找到quick_algo库，无法使用quick_algo算法")
-    print("请先安装quick_algo库：pip install quick-algo")
-    raise SystemExit(1)
+    print("请安装quick_algo库 - 在lib.quick_algo中，执行命令：python setup.py build_ext --inplace")
 
 
 import sys


### PR DESCRIPTION
## 背景
当前 `quick-algo` 在构建/发布与安装体验上存在几个问题：
- macOS 环境下构建流程对 `py-cpuinfo` 的 `flags` 信息存在硬依赖，部分环境会触发构建崩溃。
- wheel 构建覆盖平台有限，且缺少按 tag 自动发布 PyPI 的完整链路。
- 安装文档与提示中存在 `quick_algo` / `quick-algo` 混用，容易导致用户安装失败。

## 本次改动
### 1) CI 构建与发布流程
- 重构 `.github/workflows/build_dist.yml`：
  - 新增 tag 触发：`quick-algo-v*`（保留 `workflow_dispatch`）。
  - 引入多平台 wheel 构建矩阵：
    - Linux: `x86_64` / `aarch64`
    - Windows: `AMD64`
    - macOS: Intel(`x86_64`) / Apple Silicon(`arm64`)
  - 分离 `build-wheels` 与 `build-sdist`，并在 tag 场景下自动执行 `publish-pypi`。

### 2) 打包配置与元数据
- `lib/quick_algo/pyproject.toml`
  - 版本提升到 `0.1.4`。
  - `build-system.requires` 调整为 `setuptools>=68`、`wheel`、`Cython>=3.0`。
  - 完善 `cibuildwheel` 配置（含 Windows 架构项）。
- `lib/quick_algo/MANIFEST.in`
  - 调整为递归包含 `*.cpp/*.hpp/*.pxd/*.pyx/*.pyi`，减少打包缺件风险。

### 3) 构建逻辑修复（核心）
- `lib/quick_algo/setup.py`
  - 移除对 `py-cpuinfo` 的硬依赖，改为基于 `platform.machine()` 的架构判断，避免 macOS 构建崩溃点。
  - SIMD 参数仍由 `QUICK_ALGO_SIMD=1` 控制。
  - 扩展模块源码解析改为：优先使用预生成 `.cpp`，缺失时自动回退 `.pyx`；若需要 Cython 但未安装，会给出明确错误信息。
  - 明确 `package_data`，降低发布包与源码目录耦合。

### 4) 文档与安装提示
- `lib/quick_algo/README.md` 安装命令统一为 `pip install quick-algo`，补充预编译 wheel 覆盖平台说明。
- `lib/quick_algo/CHANGELOG.md` 新增 `v0.1.4` 变更记录。
- `main.py` 的导入与安装提示同步为 `quick-algo`。

## 兼容性与破坏性变更
- Python API 无破坏性变更。
- 行为层面说明：PyPI 预编译 wheel 以兼容性优先，默认不启用 SIMD；如需 SIMD，可本地源码编译并设置 `QUICK_ALGO_SIMD=1`。

## 测试与验证
- 已补齐跨平台构建与发布流水线配置，CI 将对 wheel/sdist 进行产物构建验证。
- 对源码构建路径进行了容错增强（`.cpp` 缺失时自动回退 `.pyx`）。

## 关联
- 联动 PR：`Mai-with-u/MaiBot#1527`（同步升级依赖并更新安装提示）。
